### PR TITLE
Update agent_manager.py

### DIFF
--- a/backend/agent_manager.py
+++ b/backend/agent_manager.py
@@ -1019,7 +1019,7 @@ class AgentManager:
                     and subscription_info.get("status") == "active"
                 )
                 self.logger.info(
-                    f"User {user_id} subscription for voice profile feature: Plan='{subscription_info.get("plan")}', Status='{subscription_info.get("status")}'. Voice Active: {is_pro_user_for_voice}"
+                    f"User {user_id} subscription for voice profile feature: Plan='{subscription_info.get('plan')}', Status='{subscription_info.get('status')}'. Voice Active: {is_pro_user_for_voice}"
                 )
             else:
                 self.logger.warning(


### PR DESCRIPTION
Fixing double quote issue on plan and status, this prevented the backend from launching resulting in 
`Traceback (most recent call last):
  File "H:\Scrollwise-ai\backend\server.py", line 39, in <module>
    from agent_manager import AgentManager, PROCESS_TYPES, ChapterGenerationState
  File "H:\Scrollwise-ai\backend\agent_manager.py", line 1022
    f"User {user_id} subscription for voice profile feature: Plan='{subscription_info.get("plan")}', Status='{subscription_info.get("status")}'. Voice Active: {is_pro_user_for_voice}"
                                                                                           ^^^^
SyntaxError: f-string: unmatched '('
`